### PR TITLE
Symfony 4 compatiblity

### DIFF
--- a/src/Resources/config/dbal-types.xml
+++ b/src/Resources/config/dbal-types.xml
@@ -9,7 +9,7 @@
     </parameters>
 
     <services>
-        <service id="dxi_doctrine_extension.dbal_types.registrar" class="%dxi_doctrine_extension.dbal_types.registrar.class%">
+        <service id="dxi_doctrine_extension.dbal_types.registrar" class="%dxi_doctrine_extension.dbal_types.registrar.class%" public="true">
             <argument type="collection" />
         </service>
     </services>


### PR DESCRIPTION
In symfony 4 the services are private by default. `dxi_doctrine_extension.dbal_types.registrar` is used in context of the container and therefore has to be public.