### PR TITLE
Made enum registrars public

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -26,10 +26,9 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $root = $treeBuilder->root('dxi_doctrine_extension');
+        $treeBuilder = new TreeBuilder('dxi_doctrine_extension');
 
-        $root->children()
+        $treeBuilder->getRootNode()->children()
             ->arrayNode('types')->canBeDisabled()->addDefaultsIfNotSet()
                 ->children()
                     ->arrayNode('dbal')->addDefaultsIfNotSet()

--- a/src/Resources/config/enum.dbal.xml
+++ b/src/Resources/config/enum.dbal.xml
@@ -12,7 +12,7 @@
     <services>
         <service id="dxi_doctrine_extension.enum.dbal_type_generator" class="%dxi_doctrine_extension.enum.dbal_type_generator.class%" public="false">
         </service>
-        <service id="dxi_doctrine_extension.enum.dbal_registrar" class="%dxi_doctrine_extension.enum.dbal_registrar.class%">
+        <service id="dxi_doctrine_extension.enum.dbal_registrar" class="%dxi_doctrine_extension.enum.dbal_registrar.class%" public="true">
             <argument type="service" id="dxi_doctrine_extension.enum.dbal_type_generator" />
         </service>
     </services>

--- a/src/Resources/config/enum.odm.xml
+++ b/src/Resources/config/enum.odm.xml
@@ -12,7 +12,7 @@
     <services>
         <service id="dxi_doctrine_extension.enum.odm_type_generator" class="%dxi_doctrine_extension.enum.odm_type_generator.class%" public="false">
         </service>
-        <service id="dxi_doctrine_extension.enum.odm_registrar" class="%dxi_doctrine_extension.enum.odm_registrar.class%">
+        <service id="dxi_doctrine_extension.enum.odm_registrar" class="%dxi_doctrine_extension.enum.odm_registrar.class%" public="true">
             <argument type="service" id="dxi_doctrine_extension.enum.odm_type_generator" />
         </service>
     </services>


### PR DESCRIPTION
The enum registrars do also have to be public. (Symfony4 support)